### PR TITLE
Feature: kafka event consumer 정의

### DIFF
--- a/.kafka/docker-compose-single-kafka.yml
+++ b/.kafka/docker-compose-single-kafka.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.3.10

--- a/.kafka/docker-compose-single-kafka.yml
+++ b/.kafka/docker-compose-single-kafka.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.3.10
+    environment:
+        ZOOKEEPER_CLIENT_PORT: 2181
+    ports:
+        - "2181:2181"
+  kafka:
+    image: confluentinc/cp-kafka:7.3.10
+    depends_on:
+      - zookeeper
+    ports:
+        - "9092:9092"
+    environment:
+        KAFKA_BROKER_ID: 1
+        KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+        KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+        KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     java
     id("org.springframework.boot") version "3.4.2"
+    id("io.spring.dependency-management") version "1.1.4"
 }
 
 java {
@@ -8,6 +9,8 @@ java {
         languageVersion = JavaLanguageVersion.of(21)
     }
 }
+
+ext["springCloudVersion"] = "2023.0.0"
 
 allprojects{
     // allProjects 는 root project를 비롯한 그 하위 프로젝트에게 모두 적용됨
@@ -42,6 +45,12 @@ subprojects{
         testImplementation(platform("org.junit:junit-bom:5.10.0"))
         testImplementation("org.junit.jupiter:junit-jupiter")
         testImplementation("org.springframework.boot:spring-boot-starter-test")
+    }
+
+    dependencyManagement {
+        imports {
+            mavenBom("org.springframework.cloud:spring-cloud-dependencies:${property("springCloudVersion")}")
+        }
     }
 
     tasks.test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ java {
     }
 }
 
-ext["springCloudVersion"] = "2023.0.0"
+ext["springCloudVersion"] = "2024.0.0"
 
 allprojects{
     // allProjects 는 root project를 비롯한 그 하위 프로젝트에게 모두 적용됨

--- a/consumer/build.gradle.kts
+++ b/consumer/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
     implementation(project(mapOf("path" to ":core")))
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.cloud:spring-cloud-starter-stream-kafka")
 }

--- a/consumer/src/main/java/fastcampus/event/CommentEvent.java
+++ b/consumer/src/main/java/fastcampus/event/CommentEvent.java
@@ -1,0 +1,15 @@
+package fastcampus.event;
+
+import lombok.Data;
+
+@Data
+public class CommentEvent {
+
+    /**
+     * 어떤 유저가 어떤 게시글에 어떤 댓글을 추가/삭제 했는지에 대한 이벤트 관리
+     */
+    private CommentEventType type; // ADD, REMOVE
+    private Long postId; // 게시글 ID
+    private Long userId; // 유저 ID
+    private Long commentId; // 댓글 ID
+}

--- a/consumer/src/main/java/fastcampus/event/CommentEventConsumer.java
+++ b/consumer/src/main/java/fastcampus/event/CommentEventConsumer.java
@@ -1,0 +1,16 @@
+package fastcampus.event;
+
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class CommentEventConsumer {
+
+    @Bean("comment")
+    public Consumer<CommentEvent> comment(){
+        return event -> log.info(event.toString());
+    }
+}

--- a/consumer/src/main/java/fastcampus/event/CommentEventType.java
+++ b/consumer/src/main/java/fastcampus/event/CommentEventType.java
@@ -1,0 +1,6 @@
+package fastcampus.event;
+
+public enum CommentEventType {
+    ADD,
+    REMOVE
+}

--- a/consumer/src/main/java/fastcampus/event/FollowEvent.java
+++ b/consumer/src/main/java/fastcampus/event/FollowEvent.java
@@ -1,0 +1,13 @@
+package fastcampus.event;
+
+import java.time.Instant;
+import lombok.Data;
+
+@Data
+public class FollowEvent {
+
+    private FollowEventType type;
+    private Long userId;
+    private Long targetUserId;
+    private Instant createdAt;
+}

--- a/consumer/src/main/java/fastcampus/event/FollowEventConsumer.java
+++ b/consumer/src/main/java/fastcampus/event/FollowEventConsumer.java
@@ -1,0 +1,16 @@
+package fastcampus.event;
+
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class FollowEventConsumer {
+
+    @Bean("follow")
+    public Consumer<FollowEvent> follow(){
+        return event -> log.info(event.toString());
+    }
+}

--- a/consumer/src/main/java/fastcampus/event/FollowEventType.java
+++ b/consumer/src/main/java/fastcampus/event/FollowEventType.java
@@ -1,0 +1,6 @@
+package fastcampus.event;
+
+public enum FollowEventType {
+    ADD,
+    REMOVE
+}

--- a/consumer/src/main/java/fastcampus/event/LikeEvent.java
+++ b/consumer/src/main/java/fastcampus/event/LikeEvent.java
@@ -1,0 +1,13 @@
+package fastcampus.event;
+
+import java.time.Instant;
+import lombok.Data;
+
+@Data
+public class LikeEvent {
+
+    private LikeEventType type;
+    private Long postId;
+    private Long userId;
+    private Instant createdAt;
+}

--- a/consumer/src/main/java/fastcampus/event/LikeEventConsumer.java
+++ b/consumer/src/main/java/fastcampus/event/LikeEventConsumer.java
@@ -1,0 +1,16 @@
+package fastcampus.event;
+
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class LikeEventConsumer {
+
+    @Bean("like")
+    public Consumer<LikeEvent> like(){
+        return event -> log.info(event.toString());
+    }
+}

--- a/consumer/src/main/java/fastcampus/event/LikeEventType.java
+++ b/consumer/src/main/java/fastcampus/event/LikeEventType.java
@@ -1,0 +1,6 @@
+package fastcampus.event;
+
+public enum LikeEventType {
+    ADD,
+    REMOVE
+}

--- a/consumer/src/main/resources/application-event.yml
+++ b/consumer/src/main/resources/application-event.yml
@@ -1,0 +1,23 @@
+spring:
+  cloud:
+    function:
+      definition: comment; like; follow; # 메시지를 수신했을 때 처리할 함수 정의
+    stream:
+      binder:
+        brokers: localhost:9092
+      bindings:
+        comment-in-0:
+          destination: comment # 메시지를 수신할 토픽 이름
+          content-type: application/json
+          group: notification-consumer # 컨슈머 그룹 이름
+          consumer.max-attempts: 2 # 메시지 처리 실패 시 재시도 횟수
+        like-in-0:
+            destination: like
+            content-type: application/json
+            group: notification-consumer
+            consumer.max-attempts: 2
+        follow-in-0:
+            destination: follow
+            content-type: application/json
+            group: notification-consumer
+            consumer.max-attempts: 2

--- a/consumer/src/main/resources/application-event.yml
+++ b/consumer/src/main/resources/application-event.yml
@@ -6,9 +6,9 @@ spring:
       binder:
         brokers: localhost:9092
       bindings:
-        comment-in-0:
+        comment-in-0: # comment 토픽에서 메시지를 수신하는 채널
           destination: comment # 메시지를 수신할 토픽 이름
-          content-type: application/json
+          content-type: application/json # 직렬화 / 역직렬화
           group: notification-consumer # 컨슈머 그룹 이름
           consumer.max-attempts: 2 # 메시지 처리 실패 시 재시도 횟수
         like-in-0:

--- a/consumer/src/main/resources/application.yml
+++ b/consumer/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  application:
+    name: notification-consumer
+  profiles:
+    active: local
+    include: event


### PR DESCRIPTION
1. comment event (add, remove)
- comment 함수가 comment topic에 대한 응답

2. like event
- 동일

3. follow event
- 동일

event 는 API 형식으로 JSON으로 직렬화 가능하게 작성하고,

yaml 파일에 설정을 작성 후 Event Consumer의 topic 처리 함수를 Bean으로 등록

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Kafka와 Zookeeper 기반의 단일 인스턴스 환경이 도입되어 서비스 안정성이 강화되었습니다.
  - 댓글, 좋아요, 팔로우 이벤트에 대한 새로운 메시징 처리와 알림 기능이 추가되어 실시간 사용자 상호작용이 개선되었습니다.
  - 이벤트 처리를 위한 구성 파일 업데이트로 메시지 라우팅과 재시도 설정이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->